### PR TITLE
fix: correct soldCount logic when deleting registrations

### DIFF
--- a/backend/routes/admin/registrations.ts
+++ b/backend/routes/admin/registrations.ts
@@ -424,7 +424,7 @@ const adminRegistrationsRoutes: FastifyPluginAsync = async (fastify, _options) =
 				where: { id: registration.ticketId },
 				data: {
 					soldCount: {
-						increment: 1
+						decrement: 1
 					}
 				}
 			});


### PR DESCRIPTION
## Description

I noticed a potential logic issue in [backend/routes/admin/registrations.ts](cci:7://file:///Users/davidhuang/Downloads/tickets-main/backend/routes/admin/registrations.ts:0:0-0:0) when an admin deletes a user's registration.

Currently, the code uses `increment: 1` for `soldCount`:

```typescript
// backend/routes/admin/registrations.ts

await prisma.ticket.update({
  where: { id: registration.ticketId },
  data: {
    soldCount: {
      increment: 1 // <--- Current logic
    }
  }
});
```

I am not entirely sure if this is intended, but logic suggests that deleting a registration should "free up" a ticket (decrease the sold count) rather than increase it.

If increment is used here, manually deleting a registration will actually increase the soldCount, causing the available tickets to decrease further and potentially leading to a premature "Sold Out" state.

In `backend/routes/public/registrations.ts` (user cancellation), decrement: 1 is used, which seems to be the correct behavior for releasing a ticket.

## Changes
- Changed `increment: 1` to `decrement: 1` in the registration deletion handler to correctly release ticket inventory.